### PR TITLE
Add support for structurizr config (users, roles, saml, log4j2), env, volumes, volumeMounts

### DIFF
--- a/charts/structurizr/Chart.yaml
+++ b/charts/structurizr/Chart.yaml
@@ -12,4 +12,4 @@ sources:
   - https://structurizr.com/help/on-premises
 
 version: 0.2.0
-appVersion: "3047"
+appVersion: "3142"

--- a/charts/structurizr/Chart.yaml
+++ b/charts/structurizr/Chart.yaml
@@ -11,5 +11,5 @@ keywords:
 sources:
   - https://structurizr.com/help/on-premises
 
-version: 0.1.0
+version: 0.2.0
 appVersion: "3047"

--- a/charts/structurizr/README.md
+++ b/charts/structurizr/README.md
@@ -37,7 +37,51 @@ The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| tolerations | list | `[]` |  |
+| tolerations | list | `[]` | Tolerations for pod assignment. Useful for nodes with taints. |
+| affinity | object | `{}` | Affinity settings for pod assignment. |
+| volumes | list | `[]` | List of additional volumes to be added to the pods. |
+| volumeMounts | list | `[]` | Specifies where to mount the volumes in the pod. |
+| properties | string | (multi-line string) | Custom properties configuration for Structurizr. |
+| users | string | (multi-line string) | Specifies user credentials for Structurizr. |
+| roles | string | (multi-line string) | Specifies user roles for Structurizr. |
+| saml | string | (multi-line string) | SAML identity provider metadata configuration for Structurizr authentication. |
+| log4j2 | string | (multi-line string) | Configuration settings for the logging system using Log4j2. |
+| env | list | `[]` | List of environment variables to be set for the Structurizr pod. |
+
+## Additional Configuration Details:
+
+### `volumes` and `volumeMounts`:
+You can define additional volumes to attach to the pod and specify where they are mounted. For example:
+
+```yaml
+volumes:
+  - name: my-storage
+    persistentVolumeClaim:
+      claimName: my-pvc
+volumeMounts:
+  - name: my-storage
+    mountPath: /path/in/container
+```
+
+### `properties`, `users`, `roles`, and `saml-idp-metadata`:
+These fields allow you to define multi-line strings for configurations. For instance, `properties` can be used to set Structurizr-specific configurations:
+
+```yaml
+properties: |
+  structurizr.redis.password=${REDIS_PASSWORD}
+  structurizr.authentication=saml
+```
+Similar patterns can be used for `users`, `roles`, and `saml-idp-metadata` fields.
+
+### `env`:
+You can specify additional environment variables for the Structurizr application. For instance:
+
+```yaml
+env:
+  - name: STRUCTURIZR_DATA_DIRECTORY
+    value: "/usr/local/structurizr"
+```
+This can be useful to configure aspects of Structurizr using environment variables.
 
 ## TODO
 
@@ -45,6 +89,6 @@ The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is
 - [ ] Authentication
   - [ ] File
   - [ ] LDAP
-  - [ ] SAML
+  - [x] SAML
 - [ ] Redis sessions
 - [ ] Bucket data

--- a/charts/structurizr/README.md
+++ b/charts/structurizr/README.md
@@ -1,6 +1,6 @@
 # structurizr
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3047](https://img.shields.io/badge/AppVersion-3047-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3142](https://img.shields.io/badge/AppVersion-3142-informational?style=flat-square)
 
 The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is a web-based rendering tool designed to help software development teams create software architecture diagrams and documentation.
 

--- a/charts/structurizr/README.md
+++ b/charts/structurizr/README.md
@@ -8,7 +8,7 @@ The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
+| affinity | object | `{}` | Affinity settings for pod assignment. |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
@@ -38,7 +38,6 @@ The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment. Useful for nodes with taints. |
-| affinity | object | `{}` | Affinity settings for pod assignment. |
 | volumes | list | `[]` | List of additional volumes to be added to the pods. |
 | volumeMounts | list | `[]` | Specifies where to mount the volumes in the pod. |
 | properties | string | (multi-line string) | Custom properties configuration for Structurizr. |

--- a/charts/structurizr/templates/config-map.yaml
+++ b/charts/structurizr/templates/config-map.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "structurizr.fullname" . }}-properties
+  labels:
+    {{- include "structurizr.labels" . | nindent 4 }}
+data:
+  structurizr.properties: |
+{{ .Values.properties | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "structurizr.fullname" . }}-users
+  labels:
+    {{- include "structurizr.labels" . | nindent 4 }}
+data:
+  structurizr.users: |
+{{ .Values.users | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "structurizr.fullname" . }}-roles
+  labels:
+    {{- include "structurizr.labels" . | nindent 4 }}
+data:
+  structurizr.roles: |
+{{ .Values.roles | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "structurizr.fullname" . }}-saml-idp-metadata
+  labels:
+    {{- include "structurizr.labels" . | nindent 4 }}
+data:
+  saml-idp-metadata.xml: |
+{{ .Values.saml | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "structurizr.fullname" . }}-log4j2
+  labels:
+    {{- include "structurizr.labels" . | nindent 4 }}
+data:
+  log4j2.properties: |
+{{ .Values.log4j2 | indent 4 }}

--- a/charts/structurizr/templates/deployment.yaml
+++ b/charts/structurizr/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -47,8 +51,46 @@ spec:
               path: /
               port: http
             initialDelaySeconds: 10
+          volumeMounts:
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+            - name: properties-volume
+              mountPath: /usr/local/structurizr/structurizr.properties
+              subPath: structurizr.properties
+            - name: users-volume
+              mountPath: /usr/local/structurizr/structurizr.users
+              subPath: structurizr.users
+            - name: roles-volume
+              mountPath: /usr/local/structurizr/structurizr.roles
+              subPath: structurizr.roles
+            - name: saml-idp-metadata-volume
+              mountPath: /usr/local/structurizr/saml-idp-metadata.xml
+              subPath: saml-idp-metadata.xml
+            - name: log4j2-volume
+              mountPath: /usr/local/structurizr/log4j2.properties
+              subPath: log4j2.properties
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+        - name: properties-volume
+          configMap:
+            name: {{ include "structurizr.fullname" . }}-properties
+        - name: users-volume
+          configMap:
+            name: {{ include "structurizr.fullname" . }}-users
+        - name: roles-volume
+          configMap:
+            name: {{ include "structurizr.fullname" . }}-roles
+        - name: saml-idp-metadata-volume
+          configMap:
+            name: {{ include "structurizr.fullname" . }}-saml-idp-metadata
+        - name: log4j2-volume
+          configMap:
+            name: {{ include "structurizr.fullname" . }}-log4j2
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/structurizr/values.yaml
+++ b/charts/structurizr/values.yaml
@@ -16,11 +16,13 @@ serviceAccount:
   create: true
   # Annotations to add to the service account
   annotations: {}
+    # iam.gke.io/gcp-service-account: structurizr@*.iam.gserviceaccount.com
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
+  # gke-gcsfuse/volumes: "true"
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -77,3 +79,49 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+volumes: []
+  # - name: my-storage
+  #   persistentVolumeClaim:
+  #     claimName: my-pvc
+  # - name: structurizr-bucket
+  #   csi:
+  #   driver: gcsfuse.csi.storage.gke.io
+  #   volumeAttributes:
+  #     bucketName: "structurizr-google-storage-bucket-name"
+  #     mountOptions: "implicit-dirs"
+
+volumeMounts: []
+  # - name: my-storage
+  #   mountPath: /path/in/container
+  # - name: structurizr-bucket
+  #   mountPath: /usr/local/structurizr
+
+properties: |
+#   # Your properties content goes here...
+#   structurizr.redis.password=${REDIS_PASSWORD}
+#   structurizr.authentication=saml
+#   structurizr.feature.ui.dslEditor=true
+#   structurizr.safeMode=false
+#   # and so on...
+
+users: |
+#   # Your users content goes here...
+#   {username}={hashed password}
+#   # and so on...
+
+roles: |
+#   # Your roles content goes here...
+#   {username}={role1},{role2},{role3}
+#   # and so on...
+
+saml: |
+#   # Your saml-idp-metadata.xml configuration goes here...
+
+log4j2: |
+#   # Your log4j2 configuration goes here...
+#   # See: https://github.com/structurizr/onpremises/blob/main/structurizr-onpremises/src/main/resources/log4j2.properties
+
+env: []
+  # - name: STRUCTURIZR_DATA_DIRECTORY
+  #   value: "/usr/local/structurizr"


### PR DESCRIPTION
@virtualroot Hello!

## Pull Request Description

### Update to Structurizr Helm Chart (Version: 0.2.0)

#### Changes:

1. **Version Bump**: Updated the chart version from `0.1.0` to `0.2.0`.

2. **README.md**:
   - Expanded the documentation for the following:
     - `volumes` and `volumeMounts`
     - `properties`, `users`, `roles`, and `saml-idp-metadata`
     - `env` configuration
   - Added TODO list indicating features in development and features completed.

3. **ConfigMap Templates**:
   - Introduced multiple `ConfigMap` templates for various configurations:
     - structurizr.properties
     - structurizr.users
     - structurizr.roles
     - SAML identity provider metadata
     - Log4j2 configurations

4. **Deployment Template**:
   - Added environment variables (if specified in values) to the Structurizr container.
   - Introduced volume mounts for configurations, and the corresponding volumes pointing to the ConfigMaps.

5. **Values.yaml**:
   - Introduced placeholders for the following:
     - Additional `volumes` and `volumeMounts`
     - Structurizr-specific properties, user credentials, roles, and SAML configurations
     - Log4j2 configurations
     - Environment variables

This update adds comprehensive configuration capabilities to the Structurizr Helm chart, making it flexible for various deployment scenarios.

#### How to Test:

1. Update your local helm repo.
2. Deploy the Structurizr application using the updated helm chart with custom configurations.
3. Verify that the application picks up the specified configurations.
4. Ensure that any volumes or volume mounts specified in `values.yaml` are correctly attached to the pods.

## What these changes allow for (a use case)

### `values.yaml` Notes: Using `gcsfuse`

The Structurizr Helm chart now provides the capability to use `gcsfuse` for mounting Google Cloud Storage (GCS) buckets directly to the pod. This is especially useful when you wish to leverage GCS for storing Structurizr-related data or for other data retrieval purposes.

#### Configuration:

1. **volumes**: 
   - Define a volume of type `csi` with the `gcsfuse.csi.storage.gke.io` driver.
   - Specify volume attributes like the `bucketName` and `mountOptions`.

```yaml
volumes:
  - name: structurizr-bucket
    csi:
      driver: gcsfuse.csi.storage.gke.io
      volumeAttributes:
        bucketName: "structurizr-google-storage-bucket-name"
        mountOptions: "implicit-dirs"
```

2. **volumeMounts**: 
   - Define where you'd like this volume to be mounted within the Structurizr container.

```yaml
volumeMounts:
  - name: structurizr-bucket
    mountPath: /usr/local/structurizr
```

3. **podAnnotations**: 
   - It's important to annotate the pod with `gke-gcsfuse/volumes: "true"` to indicate the use of `gcsfuse`.

```yaml
podAnnotations:
  gke-gcsfuse/volumes: "true"
```

#### Prerequisites:

- Ensure that the GCS bucket specified in `bucketName` exists.
- The nodes running this pod should have the necessary IAM permissions to access the GCS bucket.
- Ensure that `gcsfuse` is available and properly configured in your GKE cluster.

---

**Reviewer's Note**:
- Ensure that the Helm chart, when deployed with `gcsfuse` configurations, properly mounts the GCS bucket and the Structurizr application can read/write data to it as expected.
- Check for any potential security implications or best practices that might be missing in the documentation.

Thank you for your continued review!