### PR TITLE
Fix helpers.tpl issue for bumping appVersion manually when image tag is present

### DIFF
--- a/charts/structurizr/Chart.yaml
+++ b/charts/structurizr/Chart.yaml
@@ -11,5 +11,5 @@ keywords:
 sources:
   - https://structurizr.com/help/on-premises
 
-version: 0.2.0
-appVersion: "3142"
+version: 0.2.1
+appVersion: "3194"

--- a/charts/structurizr/README.md
+++ b/charts/structurizr/README.md
@@ -1,6 +1,6 @@
 # structurizr
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 3142](https://img.shields.io/badge/AppVersion-3142-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 3194](https://img.shields.io/badge/AppVersion-3194-informational?style=flat-square)
 
 The Structurizr Helm chart deploys Structurizr On premise flavor. Structurizr is a web-based rendering tool designed to help software development teams create software architecture diagrams and documentation.
 

--- a/charts/structurizr/templates/_helpers.tpl
+++ b/charts/structurizr/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "structurizr.chart" . }}
 {{ include "structurizr.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
I've added a small change here that does two things:
- Bumps default appVersion to 3194.
- Fixes issue where the `app.kubernetes.io/version` common label wasn't grabbing the manually entered version if `Values.image.tag` is present.